### PR TITLE
Make carbon and quantum armor fire-resistant

### DIFF
--- a/src/main/java/dev/ftb/mods/ftbic/item/DummyEnergyArmorItem.java
+++ b/src/main/java/dev/ftb/mods/ftbic/item/DummyEnergyArmorItem.java
@@ -24,7 +24,7 @@ import java.util.function.Consumer;
 
 public class DummyEnergyArmorItem extends ArmorItem {
 	public DummyEnergyArmorItem(EnergyArmorMaterial m, EquipmentSlot s) {
-		super(m, s, new Properties().tab(FTBIC.TAB).fireResistant());
+		super(m, s, new Properties().tab(FTBIC.TAB));
 	}
 
 	@Override

--- a/src/main/java/dev/ftb/mods/ftbic/item/DummyEnergyArmorItem.java
+++ b/src/main/java/dev/ftb/mods/ftbic/item/DummyEnergyArmorItem.java
@@ -24,7 +24,7 @@ import java.util.function.Consumer;
 
 public class DummyEnergyArmorItem extends ArmorItem {
 	public DummyEnergyArmorItem(EnergyArmorMaterial m, EquipmentSlot s) {
-		super(m, s, new Properties().tab(FTBIC.TAB));
+		super(m, s, new Properties().tab(FTBIC.TAB).fireResistant());
 	}
 
 	@Override

--- a/src/main/java/dev/ftb/mods/ftbic/item/EnergyArmorItem.java
+++ b/src/main/java/dev/ftb/mods/ftbic/item/EnergyArmorItem.java
@@ -29,7 +29,7 @@ import java.util.function.Consumer;
 
 public class EnergyArmorItem extends ArmorItem implements EnergyItemHandler {
 	public EnergyArmorItem(EnergyArmorMaterial m) {
-		super(m, EquipmentSlot.CHEST, new Properties().tab(FTBIC.TAB).fireResistant());
+		super(m, EquipmentSlot.CHEST, new Properties().tab(FTBIC.TAB));
 	}
 
 	public void damageEnergyItem(ItemStack stack, double amount) {

--- a/src/main/java/dev/ftb/mods/ftbic/item/EnergyArmorItem.java
+++ b/src/main/java/dev/ftb/mods/ftbic/item/EnergyArmorItem.java
@@ -29,7 +29,7 @@ import java.util.function.Consumer;
 
 public class EnergyArmorItem extends ArmorItem implements EnergyItemHandler {
 	public EnergyArmorItem(EnergyArmorMaterial m) {
-		super(m, EquipmentSlot.CHEST, new Properties().tab(FTBIC.TAB));
+		super(m, EquipmentSlot.CHEST, new Properties().tab(FTBIC.TAB).fireResistant());
 	}
 
 	public void damageEnergyItem(ItemStack stack, double amount) {


### PR DESCRIPTION
Makes the armor unable to be destroyed by fire or lava like netherite tools and armor.
Since netherite armor is involved in crafting each piece of both armor sets, it would make sense that they are both fire-resistant like netherite to protect players' resource investment.