### PR TITLE
[1.19] Fix Iron Furnace smelts less items per coal than a normal furnace

### DIFF
--- a/src/main/java/dev/ftb/mods/ftbic/block/entity/IronFurnaceBlockEntity.java
+++ b/src/main/java/dev/ftb/mods/ftbic/block/entity/IronFurnaceBlockEntity.java
@@ -26,6 +26,6 @@ public class IronFurnaceBlockEntity extends FurnaceBlockEntity {
 
 	@Override
 	protected int getBurnDuration(ItemStack stack) {
-		return super.getBurnDuration(stack) * 8 / FTBICConfig.MACHINES.IRON_FURNACE_ITEMS_PER_COAL.get();
+		return Math.round(super.getBurnDuration(stack) * (float) FTBICConfig.MACHINES.IRON_FURNACE_ITEMS_PER_COAL.get() / 8);
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/FTBTeam/FTB-Mods-Issues/issues/388, correcting math on Iron Furnace burn duration.

Tested in dev environment.