### PR TITLE
fix energy lack in dimensions with fixed time

### DIFF
--- a/src/main/java/dev/ftb/mods/ftbic/block/entity/generator/SolarPanelBlockEntity.java
+++ b/src/main/java/dev/ftb/mods/ftbic/block/entity/generator/SolarPanelBlockEntity.java
@@ -25,7 +25,7 @@ public class SolarPanelBlockEntity extends GeneratorBlockEntity {
 
 	@Override
 	public void handleGeneration() {
-		if (energy < energyCapacity && level.isDay() && level.canSeeSky(worldPosition.above())) {
+		if (energy < energyCapacity && level.getSkyDarken() < 4 && level.canSeeSky(worldPosition.above())) {
 			energy += Math.min(energyCapacity - energy, maxEnergyOutput);
 		}
 	}
@@ -42,6 +42,6 @@ public class SolarPanelBlockEntity extends GeneratorBlockEntity {
 	@Override
 	public void addSyncData(SyncedData data) {
 		super.addSyncData(data);
-		data.addShort(SyncedData.BAR, () -> level.isDay() && level.canSeeSky(worldPosition.above()) ? 14 : 0);
+		data.addShort(SyncedData.BAR, () -> level.getSkyDarken() < 4 && level.canSeeSky(worldPosition.above()) ? 14 : 0);
 	}
 }

--- a/src/main/java/dev/ftb/mods/ftbic/item/MechanicalElytraItem.java
+++ b/src/main/java/dev/ftb/mods/ftbic/item/MechanicalElytraItem.java
@@ -109,7 +109,7 @@ public class MechanicalElytraItem extends ArmorItem implements EnergyItemHandler
 
 	@Override
 	public void onArmorTick(ItemStack stack, Level level, Player player) {
-		if (FTBICConfig.EQUIPMENT.MECHANICAL_ELYTRA_RECHARGE.get() > 0D && !level.isClientSide() && !player.isFallFlying() && level.isDay() && level.canSeeSky(new BlockPos(player.getEyePosition(1F)))) {
+		if (FTBICConfig.EQUIPMENT.MECHANICAL_ELYTRA_RECHARGE.get() > 0D && !level.isClientSide() && !player.isFallFlying() && level.getSkyDarken() < 4 && level.canSeeSky(new BlockPos(player.getEyePosition(1F)))) {
 			insertEnergy(stack, FTBICConfig.EQUIPMENT.MECHANICAL_ELYTRA_RECHARGE.get(), false);
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/FTBTeam/FTB-Mods-Issues/issues/374
Level.class has isDay = !this.dimensionType().hasFixedTime() && this.skyDarken < 4
But we want to remove the check for a fixed time in the dimension.

Tested in dev env.
![image](https://user-images.githubusercontent.com/39002687/193456670-37de8666-3e20-461d-a4ac-5bd2e022624a.png)
