### PR TITLE
Fix Powered Furnace crash with external smelting recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [26.1.2.8]
+
+### Fixed
+
+* Powered Furnace crash when a third-party mod (for example, GeOre) registers a non-`SmeltingRecipe` subclass under `RecipeType.SMELTING`. The vanilla-recipe fallback now matches `AbstractCookingRecipe` so any cooking-recipe class is accepted.
+
 ## [26.1.2.7]
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xmx4G
 
 # Mod settings
-mod_version=7
+mod_version=8
 
 mod_id=ftbic
 maven_group=dev.ftb.mods

--- a/src/main/java/dev/ftb/mods/ftbic/block/entity/machine/MachineBlockEntity.java
+++ b/src/main/java/dev/ftb/mods/ftbic/block/entity/machine/MachineBlockEntity.java
@@ -106,7 +106,9 @@ public class MachineBlockEntity extends BasicMachineBlockEntity {
 		}
 		if (recipeType == FTBICRecipes.SMELTING && inputItems.length > 0 && !inputItems[0].isEmpty()) {
 			for (RecipeHolder<SmeltingRecipe> holder : server.recipeAccess().recipeMap().byType(RecipeType.SMELTING)) {
-				SmeltingRecipe sr = holder.value();
+				if (!(holder.value() instanceof AbstractCookingRecipe sr)) {
+					continue;
+				}
 				if (sr.input().test(inputItems[0])) {
 					cachedRecipe = adaptCooking(sr, inputItems[0]);
 					updateMaxProgress();


### PR DESCRIPTION
The Powered Furnace would crash if a third-party mod registered a recipe under `RecipeType.SMELTING` that was an `AbstractCookingRecipe` but not a direct `SmeltingRecipe` subclass. This broadens the vanilla-recipe fallback to accept any `AbstractCookingRecipe` to prevent `ClassCastException` and improve mod compatibility.