### PR TITLE
Fixes block drops and updates NeoForge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [26.1.2.9]
+
+### Fixed
+
+* **Alloy Smelter** and **Block of Enderium** now drop when mined. Both blocks were missing their block loot tables, so they vanished on break and showed no drop in JEI. The Alloy Smelter also drops its contents (inputs, outputs, upgrades, and battery) as before.
+
 ## [26.1.2.8]
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xmx4G
 
 # Mod settings
-mod_version=8
+mod_version=9
 
 mod_id=ftbic
 maven_group=dev.ftb.mods

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,8 +13,8 @@ minecraft_version=26.1.2
 minecraft_version_range=[26.1.2,)
 
 # NeoForge versions
-neoforge_version=26.1.2.29-beta
-neoforge_version_range=[26.1.2.22-beta,27)
+neoforge_version=26.1.2.73
+neoforge_version_range=[26.1.2.73,27)
 neoforge_loader_version=11
 
 # Dependencies

--- a/src/main/resources/data/ftbic/loot_table/blocks/alloy_smelter.json
+++ b/src/main/resources/data/ftbic/loot_table/blocks/alloy_smelter.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "ftbic:alloy_smelter"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/ftbic/loot_table/blocks/enderium_block.json
+++ b/src/main/resources/data/ftbic/loot_table/blocks/enderium_block.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "ftbic:enderium_block"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes the Alloy Smelter and Enderium Blocks not dropping when mined.
Also updates the NeoForge dependency to 26.1.2.73.